### PR TITLE
Tab Creation Delay improvements

### DIFF
--- a/app/js/settings.js
+++ b/app/js/settings.js
@@ -205,7 +205,10 @@ function initSettingsSave() {
     const activeNewTabsElement = document.getElementById('activeNewTabs');
     const autoLoadIntoTextareaElement = document.getElementById('autoLoadIntoTextArea');
     const delayTabLoadingElement = document.getElementById('delayUntilFocus');
-    const tabCreationDelay = parseInt(tabCreationDelayElement.value);
+    let tabCreationDelay = parseInt(tabCreationDelayElement.value);
+    if (tabCreationDelayElement.value % 1 !== 0) {
+        tabCreationDelay = parseFloat(tabCreationDelayElement.value);
+    }
     let nightMode = 0;
     let autoOpenLists = 0;
     let activeNewTabs = 0;

--- a/app/settings.html
+++ b/app/settings.html
@@ -26,9 +26,13 @@
                     <div class="input-group-prepend">
                         <span class="input-group-text" id="delay-addon">Tab creation delay (Seconds):</span>
                     </div>
-                    <input aria-describedby="delay-addon" class="form-control" id="tabCreationDelay"
+                    <input aria-describedby="delay-addon"
+                           class="form-control"
+                           id="tabCreationDelay"
                            placeholder="Delay in seconds"
-                           type="number">
+                           step=".1"
+                           type="number"
+                    >
                 </div>
             </div>
             <hr>


### PR DESCRIPTION
- User can now specify tab creation delay to decimal points, rather than only allowing whole numbers perviously. Requsted in #8 