### PR TITLE
FIX extractURLFromString: escape url characters

### DIFF
--- a/app/js/utility.js
+++ b/app/js/utility.js
@@ -248,7 +248,7 @@ function encodeSearchQuery(string) {
  * @param {*} string
  */
 function extractURLFromString(string) {
-    const primaryURLRegex = /(https?:\/\/[\w-]+\.[a-z0-9\/:%_+.,#?!@&=-~]+)/;
+    const primaryURLRegex = /(https?:\/\/[\w-]+\.[a-z0-9\/:\%\_\+\.\,\#\?\!\@\&\=\-\~]+)/;
     const secondaryURLRegex = /(https?:\/\/[^ ]*)/;
     let url;
     if (string.match(primaryURLRegex)) {


### PR DESCRIPTION
fixes #233 
its safer to escape the chars we want to be treated as chars